### PR TITLE
#173: Parallelize slow checks

### DIFF
--- a/.github/workflows/matrix-slow.yml
+++ b/.github/workflows/matrix-slow.yml
@@ -1,0 +1,37 @@
+name: Build Matrix (Slow Tests)
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "Generates the slow test build matrix"
+        value: ${{ jobs.set-matrix-slow.outputs.matrix }}
+
+jobs:
+  set-matrix-slow:
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
+    steps:
+      - name: Check out Repository
+        id: check-out-repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python & Poetry Environment
+        id: set-up-python-and-poetry-environment
+        uses: exasol/python-toolbox/.github/actions/python-environment@v7
+        with:
+          python-version: "3.10"
+          poetry-version: "2.3.0"
+
+      - name: Generate Matrix
+        id: generate-matrix
+        run: poetry run -- nox -s matrix:slow
+
+      - name: Set Matrix
+        id: set-matrix
+        run: |
+          echo "matrix=$(poetry run -- nox -s matrix:slow)" >> $GITHUB_OUTPUT
+
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/slow-checks.yml
+++ b/.github/workflows/slow-checks.yml
@@ -4,12 +4,22 @@ on:
   workflow_call:
 
 jobs:
+  build-slow-matrix:
+    name: Build Slow Matrix
+    uses: ./.github/workflows/matrix-slow.yml
+    permissions:
+      contents: read
 
   run-integration-tests:
-    name: Run Integration Tests
+    name: Run Integration Tests (${{ matrix.test-name }})
+    needs:
+      - build-slow-matrix
     runs-on: "ubuntu-24.04"
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.build-slow-matrix.outputs.matrix) }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +36,10 @@ jobs:
 
       - name: Run Integration Tests
         id: run-integration-tests
-        run: poetry run -- nox -s test:integration -- --coverage
+        run: |
+          poetry run coverage run \
+            --rcfile=pyproject.toml \
+            -m pytest -v "${{ matrix.test-path }}"
         env:
           SAAS_HOST: ${{ secrets.INTEGRATION_TEAM_SAAS_STAGING_HOST }}
           SAAS_ACCOUNT_ID: ${{ secrets.INTEGRATION_TEAM_SAAS_STAGING_ACCOUNT_ID }}
@@ -38,6 +51,6 @@ jobs:
         id: upload-artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-python3.10-slow
+          name: coverage-python3.10-slow-${{ matrix.test-name }}
           path: .coverage
           include-hidden-files: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,19 @@ nox.options.sessions = ["format:fix"]
 DEST_DIR = "exasol/saas/client/openapi"
 
 
+def _slow_test_matrix() -> dict[str, list[dict[str, str]]]:
+    files = sorted(Path("test/integration").glob("test_*.py"))
+    return {
+        "include": [
+            {
+                "test-name": path.stem.removeprefix("test_").replace("_", "-"),
+                "test-path": str(path),
+            }
+            for path in files
+        ]
+    }
+
+
 def _download_openapi_json() -> Path:
     url = f"{SAAS_HOST}/openapi.json"
     response = requests.get(url)
@@ -125,3 +138,9 @@ def check_api_outdated(session: Session):
     """
     generate_api(session)
     session.run("git", "diff", "--exit-code", DEST_DIR)
+
+
+@nox.session(name="matrix:slow", python=False)
+def slow_matrix(session: Session):
+    """Output the build matrix for slow integration tests as JSON."""
+    print(json.dumps(_slow_test_matrix()))


### PR DESCRIPTION
## What changed
This PR adds the dynamic slow-test matrix workflow 

Fixes #173

## Why it changed
The slow integration checks were previously bundled into a single job. This splits them into a generated matrix so they can run in parallel without mixing in functional API changes.

## Impact
Slow checks should complete faster and each slow integration target becomes independently visible in CI.
