### PR TITLE
Support configurable database node counts

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -15,6 +15,8 @@ Besides there are many formal and syntactic changes
 
 ## Summary
 
+* #147: Added `num_nodes` support to the handwritten database creation helpers.
+
 ## Refactorings
 
 * #160: Updated PTB to version 7.0.0

--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -1,9 +1,28 @@
 # Unreleased
 
-This release updates the Python API generated from file `openapi.json`.
+## Summary
+
+This release enables configurable database node counts in the handwritten
+database helpers, updates the project tooling to version 7.0.0, and
+parallelizes slow integration checks with a generated workflow matrix. It
+also includes the generated OpenAPI updates described below.
+
+Since version 2.10.0, the generated Python API client has been updated from
+a newer SaaS API specification. The update adds database MCP status and
+toggle operations, expands the generated model coverage for account,
+billing, worksheet, support, invitation, health, and related resources, and
+improves endpoint parameter and response schema definitions.
+
+The semantic API changes include:
+
+* `GET /api/v1/accounts/{accountId}/databases/{databaseId}/mcp` retrieves the database MCP status.
+* `POST /api/v1/accounts/{accountId}/databases/{databaseId}/mcp` enables or disables database MCP.
+* MCP status, configuration, connection, and enable/disable action models have been added.
+* Generated models for account, billing, worksheet, support, invitation, health, and related resources have been added.
+* Endpoint parameters and response schemas now use explicit typed definitions in more API operations.
+* API error and database schemas have been updated, including optional error fields and database MCP status information.
 
 * For endpoint `/api/v1/accounts/{accountId}/databases/{databaseId}/clusters/{clusterId}/stop`, method "put", parameter `actor` has been added.
-* For many endpoints the data type "string" has been replaced by a reference to model data type.
 
 Besides there are many formal and syntactic changes
 * indent was decreased from 4 to 2 spaces
@@ -13,10 +32,11 @@ Besides there are many formal and syntactic changes
 * `"description": "No content"` has been replaced by
  `"description": "No content", "content": {}`
 
-## Summary
+## Features
 
 * #147: Added `num_nodes` support to the handwritten database creation helpers.
 
 ## Refactorings
 
 * #160: Updated PTB to version 7.0.0
+* #173: Parallelized slow integration checks with a generated workflow matrix.

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -40,6 +40,7 @@ from exasol.saas.client.openapi.api.databases import (
     create_database,
     delete_database,
     get_database,
+    get_database_settings,
     list_databases,
 )
 from exasol.saas.client.openapi.api.security import (
@@ -351,6 +352,7 @@ class OpenApiAccess:
         cluster_size: str = "XS",
         region: str = "eu-central-1",
         idle_time: timedelta | None = None,
+        num_nodes: int | None = None,
     ) -> ExasolDatabase | None:
         def minutes(x: timedelta) -> int:
             return x.seconds // 60
@@ -372,6 +374,8 @@ class OpenApiAccess:
             region=region,
             stream_type="innovation-release",
         )
+        if num_nodes is not None:
+            database_spec.num_nodes = num_nodes
         resp = create_database.sync(
             self._account_id,
             client=self._client,
@@ -517,12 +521,14 @@ class OpenApiAccess:
         keep: bool = False,
         ignore_delete_failure: bool = False,
         idle_time: timedelta | None = None,
+        num_nodes: int | None = None,
     ):
         db = None
         try:
             db = self.create_database(
                 name,
                 idle_time=idle_time,
+                num_nodes=num_nodes,
             )
             yield db
         finally:
@@ -553,6 +559,39 @@ class OpenApiAccess:
         return ensure_type(
             ExasolDatabase, resp, f"Failed to get database {database_id}"
         )
+
+    def get_database_settings(
+        self,
+        database_id: str,
+    ) -> openapi.models.DatabaseSettings | None:
+        def is_retry(resp: ApiError) -> bool:
+            return _is_not_found(resp)
+
+        @interval_retry(
+            interval=timedelta(seconds=5),
+            timeout=timedelta(minutes=2),
+        )
+        def retrieve_settings() -> openapi.models.DatabaseSettings:
+            resp = get_database_settings.sync(
+                self._account_id,
+                database_id,
+                client=self._client,
+            )
+            _log_api_output(
+                "get_database_settings.sync",
+                resp,
+                account_id=self._account_id,
+                database_id=database_id,
+            )
+            if isinstance(resp, ApiError) and is_retry(resp):
+                raise TryAgain
+            return ensure_type(
+                openapi.models.DatabaseSettings,
+                resp,
+                f"Failed to get settings of database {database_id}",
+            )
+
+        return retrieve_settings()
 
     def wait_until_running(
         self,

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -372,10 +372,9 @@ class OpenApiAccess:
             initial_cluster=cluster_spec,
             provider="aws",
             region=region,
+            num_nodes=num_nodes if num_nodes is not None else UNSET,
             stream_type="innovation-release",
         )
-        if num_nodes is not None:
-            database_spec.num_nodes = num_nodes
         resp = create_database.sync(
             self._account_id,
             client=self._client,
@@ -563,7 +562,7 @@ class OpenApiAccess:
     def get_database_settings(
         self,
         database_id: str,
-    ) -> openapi.models.DatabaseSettings | None:
+    ) -> openapi.models.DatabaseSettings:
         def is_retry(resp: ApiError) -> bool:
             return _is_not_found(resp)
 

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -564,15 +564,12 @@ class OpenApiAccess:
             ExasolDatabase, resp, f"Failed to get database {database_id}"
         )
 
-    def get_database_settings(
-        self,
-        database_id: str,
-    ) -> openapi.models.DatabaseSettings:
+    def _wait_until_database_settings_available(self, database_id: str) -> None:
         @interval_retry(
             interval=timedelta(seconds=5),
             timeout=timedelta(minutes=10),
         )
-        def wait_until_created() -> None:
+        def check_database() -> None:
             database = self.get_database(database_id)
             if database is None:
                 LOG.info("- Database status: unavailable ...")
@@ -586,7 +583,13 @@ class OpenApiAccess:
                 LOG.info("- Database was created less than two minutes ago ...")
                 raise TryAgain
 
-        wait_until_created()
+        check_database()
+
+    def get_database_settings(
+        self,
+        database_id: str,
+    ) -> openapi.models.DatabaseSettings:
+        self._wait_until_database_settings_available(database_id)
 
         def is_retry(resp: ApiError) -> bool:
             return _is_not_found(resp)

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -568,6 +568,18 @@ class OpenApiAccess:
         self,
         database_id: str,
     ) -> openapi.models.DatabaseSettings:
+        @interval_retry(
+            interval=timedelta(seconds=5),
+            timeout=timedelta(minutes=10),
+        )
+        def wait_until_created() -> None:
+            database = self.get_database(database_id)
+            if database.status is Status.TOCREATE:
+                LOG.info("- Database status: %s ...", database.status)
+                raise TryAgain
+
+        wait_until_created()
+
         def is_retry(resp: ApiError) -> bool:
             return _is_not_found(resp)
 

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -21,7 +21,10 @@ from tenacity import (
     TryAgain,
     retry,
 )
-from tenacity.retry import retry_if_exception_type
+from tenacity.retry import (
+    retry_base,
+    retry_if_exception_type,
+)
 from tenacity.stop import stop_after_delay
 from tenacity.wait import (
     wait_exponential,
@@ -40,7 +43,11 @@ from exasol.saas.client.openapi.api.databases import (
     create_database,
     delete_database,
     get_database,
-    get_database_settings,
+)
+from exasol.saas.client.openapi.api.databases import (
+    get_database_settings as get_database_settings_api,
+)
+from exasol.saas.client.openapi.api.databases import (
     list_databases,
 )
 from exasol.saas.client.openapi.api.security import (
@@ -62,8 +69,16 @@ LOG = logging.getLogger(__name__)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
-def interval_retry(interval: timedelta, timeout: timedelta):
-    return tenacity.retry(wait=wait_fixed(interval), stop=stop_after_delay(timeout))
+def interval_retry(
+    interval: timedelta,
+    timeout: timedelta,
+    retry: retry_base = retry_if_exception_type(),
+):
+    return tenacity.retry(
+        wait=wait_fixed(interval),
+        stop=stop_after_delay(timeout),
+        retry=retry,
+    )
 
 
 def timestamp_name(project_short_tag: str | None = None) -> str:
@@ -577,6 +592,7 @@ class OpenApiAccess:
             if database.status is Status.TOCREATE:
                 LOG.info("- Database status: %s ...", database.status)
                 raise TryAgain
+            # SaaS returns default settings until two minutes after creation.
             if database.created_at + timedelta(minutes=2) > datetime.now(
                 tz=database.created_at.tzinfo
             ):
@@ -597,9 +613,10 @@ class OpenApiAccess:
         @interval_retry(
             interval=timedelta(seconds=5),
             timeout=timedelta(minutes=2),
+            retry=retry_if_exception_type(TryAgain),
         )
         def retrieve_settings() -> openapi.models.DatabaseSettings:
-            resp = get_database_settings.sync(
+            resp = get_database_settings_api.sync(
                 self._account_id,
                 database_id,
                 client=self._client,

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -572,14 +572,21 @@ class OpenApiAccess:
             interval=timedelta(seconds=5),
             timeout=timedelta(minutes=10),
         )
-        def wait_until_starting() -> None:
+        def wait_until_created() -> None:
             database = self.get_database(database_id)
-            status = database.status if database else None
-            if status not in {Status.STARTING, Status.RUNNING}:
-                LOG.info("- Database status: %s ...", status)
+            if database is None:
+                LOG.info("- Database status: unavailable ...")
+                raise TryAgain
+            if database.status is Status.TOCREATE:
+                LOG.info("- Database status: %s ...", database.status)
+                raise TryAgain
+            if database.created_at + timedelta(minutes=2) > datetime.now(
+                tz=database.created_at.tzinfo
+            ):
+                LOG.info("- Database was created less than two minutes ago ...")
                 raise TryAgain
 
-        wait_until_starting()
+        wait_until_created()
 
         def is_retry(resp: ApiError) -> bool:
             return _is_not_found(resp)

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -572,14 +572,14 @@ class OpenApiAccess:
             interval=timedelta(seconds=5),
             timeout=timedelta(minutes=10),
         )
-        def wait_until_created() -> None:
+        def wait_until_starting() -> None:
             database = self.get_database(database_id)
             status = database.status if database else None
-            if status is None or status is Status.TOCREATE:
+            if status not in {Status.STARTING, Status.RUNNING}:
                 LOG.info("- Database status: %s ...", status)
                 raise TryAgain
 
-        wait_until_created()
+        wait_until_starting()
 
         def is_retry(resp: ApiError) -> bool:
             return _is_not_found(resp)

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -574,8 +574,9 @@ class OpenApiAccess:
         )
         def wait_until_created() -> None:
             database = self.get_database(database_id)
-            if database.status is Status.TOCREATE:
-                LOG.info("- Database status: %s ...", database.status)
+            status = database.status if database else None
+            if status is None or status is Status.TOCREATE:
+                LOG.info("- Database status: %s ...", status)
                 raise TryAgain
 
         wait_until_created()

--- a/exasol/saas/client/api_access.py
+++ b/exasol/saas/client/api_access.py
@@ -375,6 +375,11 @@ class OpenApiAccess:
             num_nodes=num_nodes if num_nodes is not None else UNSET,
             stream_type="innovation-release",
         )
+        if LOG.isEnabledFor(logging.DEBUG):
+            LOG.debug(
+                "create_database database spec: %s",
+                _serialize_api_output(database_spec),
+            )
         resp = create_database.sync(
             self._account_id,
             client=self._client,

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -67,6 +67,15 @@ def database_name(project_short_tag) -> str:
     return timestamp_name(project_short_tag)
 
 
+@pytest.fixture
+def local_name(project_short_tag: str | None) -> str:
+    """
+    Other than global fixture database_name this fixture uses scope
+    "function" to generate an individual name for each test case.
+    """
+    return timestamp_name(project_short_tag)
+
+
 @pytest.fixture(scope="session")
 def allow_connection(api_access) -> None:
     """

--- a/test/integration/test_database_lifecycle.py
+++ b/test/integration/test_database_lifecycle.py
@@ -1,16 +1,10 @@
 import logging
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 
 import pytest
 from tenacity import RetryError
 
 from exasol.saas.client import PROMISING_STATES
-from exasol.saas.client.api_access import (
-    timestamp_name,
-)
 from exasol.saas.client.openapi.models.exasol_database import ExasolDatabase
 
 LOG = logging.getLogger(__name__)
@@ -18,15 +12,6 @@ logging.basicConfig(
     level=logging.INFO,
     format="[%(levelname)s] %(message)s",
 )
-
-
-@pytest.fixture
-def local_name(project_short_tag: str | None) -> str:
-    """
-    Other than global fixture database_name this fixture uses scope
-    "function" to generate an individual name for each test case in this file.
-    """
-    return timestamp_name(project_short_tag)
 
 
 def test_lifecycle(api_access, local_name):
@@ -52,20 +37,16 @@ def test_lifecycle(api_access, local_name):
         return api_access.get_connection(db.id, clusters[0].id)
 
     with api_access.database(local_name, ignore_delete_failure=True) as db:
-        start = datetime.now()
-        # verify state and clusters of created database
         assert db.status in PROMISING_STATES and db.clusters.total == 1
 
         with pytest.raises(RetryError):
             wait_until_running_too_short(db)
 
-        # verify database is listed
         assert db.id in api_access.list_database_ids()
 
         con = get_connection(db)
         assert con.db_username is not None and con.port == 8563
 
-        # delete database and verify database is not listed anymore
         api_access.delete_database(db.id)
         api_access.wait_until_deleted(db.id)
         assert db.id not in api_access.list_database_ids()

--- a/test/integration/test_database_lifecycle.py
+++ b/test/integration/test_database_lifecycle.py
@@ -45,7 +45,8 @@ def test_lifecycle(api_access, local_name):
         assert db.id in api_access.list_database_ids()
 
         con = get_connection(db)
-        assert con.db_username is not None and con.port == 8563
+        assert con.db_username is not None
+        assert con.port == 8563
 
         api_access.delete_database(db.id)
         api_access.wait_until_deleted(db.id)

--- a/test/integration/test_database_lifecycle.py
+++ b/test/integration/test_database_lifecycle.py
@@ -37,7 +37,8 @@ def test_lifecycle(api_access, local_name):
         return api_access.get_connection(db.id, clusters[0].id)
 
     with api_access.database(local_name, ignore_delete_failure=True) as db:
-        assert db.status in PROMISING_STATES and db.clusters.total == 1
+        assert db.status in PROMISING_STATES
+        assert db.clusters.total == 1
 
         with pytest.raises(RetryError):
             wait_until_running_too_short(db)

--- a/test/integration/test_database_num_nodes.py
+++ b/test/integration/test_database_num_nodes.py
@@ -1,0 +1,14 @@
+def test_create_database_with_two_nodes(api_access, local_name):
+    """
+    This integration test verifies that the handwritten helper forwards
+    `num_nodes` and the created database reports that setting back.
+    """
+    with api_access.database(
+        local_name,
+        ignore_delete_failure=True,
+        num_nodes=2,
+    ) as db:
+        settings = api_access.get_database_settings(db.id)
+
+        assert settings is not None
+        assert settings.num_nodes == 2

--- a/test/integration/test_database_num_nodes.py
+++ b/test/integration/test_database_num_nodes.py
@@ -10,5 +10,4 @@ def test_create_database_with_two_nodes(api_access, local_name):
     ) as db:
         settings = api_access.get_database_settings(db.id)
 
-        assert settings is not None
         assert settings.num_nodes == 2

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -111,7 +111,9 @@ def get_database_mock(monkeypatch, side_effect) -> Mock:
 
 
 def database_response(
-    name: str = "db", status: Status = Status.CREATING
+    name: str = "db",
+    status: Status = Status.CREATING,
+    created_at: datetime = datetime(2026, 1, 1),
 ) -> ExasolDatabase:
     return ExasolDatabase(
         status=status,
@@ -120,7 +122,7 @@ def database_response(
         clusters=ExasolDatabaseClusters(total=1, running=0),
         provider="aws",
         region="eu-central-1",
-        created_at=datetime(2026, 1, 1),
+        created_at=created_at,
         created_by="tester",
         mcp_status="disabled",
     )
@@ -318,7 +320,7 @@ def test_get_database_settings_retries_transient_not_found(
     assert get_settings.call_count == 2
 
 
-def test_get_database_settings_waits_until_database_is_starting(
+def test_get_database_settings_waits_until_database_is_created(
     api_mock, monkeypatch
 ) -> None:
     monkeypatch.setattr(
@@ -330,7 +332,6 @@ def test_get_database_settings_waits_until_database_is_starting(
         [
             database_response(status=Status.TOCREATE),
             database_response(status=Status.CREATING),
-            database_response(status=Status.STARTING),
         ],
     )
     get_settings = get_database_settings_mock(
@@ -341,7 +342,44 @@ def test_get_database_settings_waits_until_database_is_starting(
     result = api_mock.get_database_settings("db-id")
 
     assert result.num_nodes == 2
-    assert get_database.call_count == 3
+    assert get_database.call_count == 2
+    assert get_settings.call_count == 1
+
+
+def test_get_database_settings_waits_two_minutes_after_database_creation(
+    api_mock, monkeypatch
+) -> None:
+    from exasol.saas.client import api_access as api_access_module
+
+    monkeypatch.setattr(
+        "exasol.saas.client.api_access.interval_retry",
+        immediate_retry,
+    )
+    created_at = datetime(2026, 1, 1)
+    get_database = get_database_mock(
+        monkeypatch,
+        [
+            database_response(created_at=created_at),
+            database_response(created_at=created_at),
+        ],
+    )
+    get_settings = get_database_settings_mock(
+        monkeypatch,
+        [database_settings_response()],
+    )
+    now = Mock(
+        side_effect=[
+            created_at + timedelta(minutes=1),
+            created_at + timedelta(minutes=2),
+        ]
+    )
+    datetime_mock = Mock(now=now)
+    monkeypatch.setattr(api_access_module, "datetime", datetime_mock)
+
+    result = api_mock.get_database_settings("db-id")
+
+    assert result.num_nodes == 2
+    assert get_database.call_count == 2
     assert get_settings.call_count == 1
 
 

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -261,6 +261,20 @@ def test_create_database_num_nodes(
     assert body.num_nodes == expected_num_nodes
 
 
+def test_create_database_logs_database_spec(api_mock, monkeypatch, caplog) -> None:
+    create_database_mock(
+        monkeypatch,
+        [database_response("logged-db")],
+    )
+    caplog.set_level(logging.DEBUG, logger="exasol.saas.client.api_access")
+
+    api_mock.create_database("logged-db", num_nodes=2)
+
+    assert "create_database database spec" in caplog.text
+    assert "'name': 'logged-db'" in caplog.text
+    assert "'numNodes': 2" in caplog.text
+
+
 def test_database_context_forwards_num_nodes(api_mock, monkeypatch) -> None:
     create = Mock(return_value=database_response("db-with-context"))
     delete = Mock()

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -79,7 +79,7 @@ def create_database_mock(monkeypatch, side_effect) -> Mock:
 
 
 def get_database_settings_mock(monkeypatch, side_effect) -> Mock:
-    from exasol.saas.client.api_access import get_database_settings as api
+    from exasol.saas.client.api_access import get_database_settings_api as api
 
     mock = Mock(side_effect=side_effect)
     monkeypatch.setattr(api, "sync", mock)
@@ -386,21 +386,19 @@ def test_get_database_settings_waits_two_minutes_after_database_creation(
 def test_get_database_settings_raises_non_retryable_error(
     api_mock, monkeypatch
 ) -> None:
-    monkeypatch.setattr(
-        "exasol.saas.client.api_access.interval_retry",
-        lambda *_args, **_kwargs: (lambda func: func),
-    )
     get_database_mock(
         monkeypatch,
         [database_response(status=Status.RUNNING)],
     )
-    get_database_settings_mock(
+    get_settings = get_database_settings_mock(
         monkeypatch,
         [api_error(500, "boom")],
     )
 
     with pytest.raises(OpenApiError, match="Failed to get settings of database db-id"):
         api_mock.get_database_settings("db-id")
+
+    assert get_settings.call_count == 1
 
 
 def test_log_api_output_serializes_payloads(caplog) -> None:

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -301,7 +301,7 @@ def test_get_database_settings_retries_transient_not_found(
     )
     get_database = get_database_mock(
         monkeypatch,
-        [database_response()],
+        [database_response(status=Status.RUNNING)],
     )
     get_settings = get_database_settings_mock(
         monkeypatch,
@@ -318,7 +318,7 @@ def test_get_database_settings_retries_transient_not_found(
     assert get_settings.call_count == 2
 
 
-def test_get_database_settings_waits_until_database_is_created(
+def test_get_database_settings_waits_until_database_is_starting(
     api_mock, monkeypatch
 ) -> None:
     monkeypatch.setattr(
@@ -329,7 +329,8 @@ def test_get_database_settings_waits_until_database_is_created(
         monkeypatch,
         [
             database_response(status=Status.TOCREATE),
-            database_response(),
+            database_response(status=Status.CREATING),
+            database_response(status=Status.STARTING),
         ],
     )
     get_settings = get_database_settings_mock(
@@ -340,7 +341,7 @@ def test_get_database_settings_waits_until_database_is_created(
     result = api_mock.get_database_settings("db-id")
 
     assert result.num_nodes == 2
-    assert get_database.call_count == 2
+    assert get_database.call_count == 3
     assert get_settings.call_count == 1
 
 
@@ -353,7 +354,7 @@ def test_get_database_settings_raises_non_retryable_error(
     )
     get_database_mock(
         monkeypatch,
-        [database_response()],
+        [database_response(status=Status.RUNNING)],
     )
     get_database_settings_mock(
         monkeypatch,

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -70,6 +70,20 @@ def delete_mock(monkeypatch, side_effect) -> Mock:
     return mock
 
 
+def create_database_mock(monkeypatch, side_effect) -> Mock:
+    from exasol.saas.client.api_access import create_database as api
+
+    mock = Mock(side_effect=side_effect)
+    monkeypatch.setattr(api, "sync", mock)
+    return mock
+
+
+def get_database_settings_mock(monkeypatch, side_effect) -> Mock:
+    from exasol.saas.client.api_access import get_database_settings as api
+
+    mock = Mock(side_effect=side_effect)
+    monkeypatch.setattr(api, "sync", mock)
+    return mock
 def list_allowed_ips_mock(monkeypatch, side_effect) -> Mock:
     from exasol.saas.client.api_access import list_allowed_i_ps as api
 
@@ -222,6 +236,80 @@ def test_timestamp_name() -> None:
     assert all(tag == "TEST" for tag in tags)
 
 
+@pytest.mark.parametrize(
+    "num_nodes, expected_num_nodes",
+    [
+        pytest.param(None, UNSET, id="uses_backend_default"),
+        pytest.param(2, 2, id="forwards_explicit_value"),
+    ],
+)
+def test_create_database_num_nodes(
+    api_mock, monkeypatch, num_nodes, expected_num_nodes
+) -> None:
+    create = create_database_mock(
+        monkeypatch,
+        [database_response("db-with-nodes")],
+    )
+
+    result = api_mock.create_database("db-with-nodes", num_nodes=num_nodes)
+
+    assert result is not None
+    assert create.called
+    body = create.call_args.kwargs["body"]
+    assert body.num_nodes == expected_num_nodes
+
+
+def test_database_context_forwards_num_nodes(api_mock, monkeypatch) -> None:
+    create = Mock(return_value=database_response("db-with-context"))
+    delete = Mock()
+    monkeypatch.setattr(api_mock, "create_database", create)
+    monkeypatch.setattr(api_mock, "delete_database", delete)
+
+    with api_mock.database("db-with-context", num_nodes=2) as db:
+        assert db is not None
+        assert db.name == "db-with-context"
+
+    assert create.call_args.args == ("db-with-context",)
+    assert create.call_args.kwargs == {"idle_time": None, "num_nodes": 2}
+    delete.assert_called_once_with("db-id", False)
+
+
+def test_get_database_settings_retries_transient_not_found(
+    api_mock, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "exasol.saas.client.api_access.interval_retry",
+        immediate_retry,
+    )
+    get_settings = get_database_settings_mock(
+        monkeypatch,
+        [
+            api_error(404, "User/Database not found"),
+            database_settings_response(),
+        ],
+    )
+
+    result = api_mock.get_database_settings("db-id")
+
+    assert result is not None
+    assert result.num_nodes == 2
+    assert get_settings.call_count == 2
+
+
+def test_get_database_settings_raises_non_retryable_error(
+    api_mock, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "exasol.saas.client.api_access.interval_retry",
+        lambda *_args, **_kwargs: (lambda func: func),
+    )
+    get_database_settings_mock(
+        monkeypatch,
+        [api_error(500, "boom")],
+    )
+
+    with pytest.raises(OpenApiError, match="Failed to get settings of database db-id"):
+        api_mock.get_database_settings("db-id")
 def test_log_api_output_serializes_payloads(caplog) -> None:
     caplog.set_level(logging.DEBUG, logger="exasol.saas.client.api_access")
 

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -293,7 +293,6 @@ def test_get_database_settings_retries_transient_not_found(
 
     result = api_mock.get_database_settings("db-id")
 
-    assert result is not None
     assert result.num_nodes == 2
     assert get_settings.call_count == 2
 

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -84,6 +84,8 @@ def get_database_settings_mock(monkeypatch, side_effect) -> Mock:
     mock = Mock(side_effect=side_effect)
     monkeypatch.setattr(api, "sync", mock)
     return mock
+
+
 def list_allowed_ips_mock(monkeypatch, side_effect) -> Mock:
     from exasol.saas.client.api_access import list_allowed_i_ps as api
 
@@ -310,6 +312,8 @@ def test_get_database_settings_raises_non_retryable_error(
 
     with pytest.raises(OpenApiError, match="Failed to get settings of database db-id"):
         api_mock.get_database_settings("db-id")
+
+
 def test_log_api_output_serializes_payloads(caplog) -> None:
     caplog.set_level(logging.DEBUG, logger="exasol.saas.client.api_access")
 

--- a/test/unit/test_api_access.py
+++ b/test/unit/test_api_access.py
@@ -110,9 +110,11 @@ def get_database_mock(monkeypatch, side_effect) -> Mock:
     return mock
 
 
-def database_response(name: str = "db") -> ExasolDatabase:
+def database_response(
+    name: str = "db", status: Status = Status.CREATING
+) -> ExasolDatabase:
     return ExasolDatabase(
-        status=Status.CREATING,
+        status=status,
         id="db-id",
         name=name,
         clusters=ExasolDatabaseClusters(total=1, running=0),
@@ -297,6 +299,10 @@ def test_get_database_settings_retries_transient_not_found(
         "exasol.saas.client.api_access.interval_retry",
         immediate_retry,
     )
+    get_database = get_database_mock(
+        monkeypatch,
+        [database_response()],
+    )
     get_settings = get_database_settings_mock(
         monkeypatch,
         [
@@ -308,7 +314,34 @@ def test_get_database_settings_retries_transient_not_found(
     result = api_mock.get_database_settings("db-id")
 
     assert result.num_nodes == 2
+    assert get_database.call_count == 1
     assert get_settings.call_count == 2
+
+
+def test_get_database_settings_waits_until_database_is_created(
+    api_mock, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "exasol.saas.client.api_access.interval_retry",
+        immediate_retry,
+    )
+    get_database = get_database_mock(
+        monkeypatch,
+        [
+            database_response(status=Status.TOCREATE),
+            database_response(),
+        ],
+    )
+    get_settings = get_database_settings_mock(
+        monkeypatch,
+        [database_settings_response()],
+    )
+
+    result = api_mock.get_database_settings("db-id")
+
+    assert result.num_nodes == 2
+    assert get_database.call_count == 2
+    assert get_settings.call_count == 1
 
 
 def test_get_database_settings_raises_non_retryable_error(
@@ -317,6 +350,10 @@ def test_get_database_settings_raises_non_retryable_error(
     monkeypatch.setattr(
         "exasol.saas.client.api_access.interval_retry",
         lambda *_args, **_kwargs: (lambda func: func),
+    )
+    get_database_mock(
+        monkeypatch,
+        [database_response()],
     )
     get_database_settings_mock(
         monkeypatch,


### PR DESCRIPTION
## What changed
This PR adds configurable database node counts on top of PR 2.

It includes:
- `num_nodes` support in the handwritten database creation helpers
- unit coverage for `num_nodes` forwarding
- the integration-test split that isolates the node-count scenario into `test_database_num_nodes.py`
- the matching changelog entry

## Impact
Callers using the handwritten access helpers can now request explicit database node counts, and the node-count integration scenario is separated from the general lifecycle coverage.